### PR TITLE
feat(Attribute): custom attribute response api

### DIFF
--- a/mstore-api/functions/index.php
+++ b/mstore-api/functions/index.php
@@ -565,6 +565,70 @@ function customProductResponse($response, $object, $request)
     return $response;
 }
 
+/// Clone from wp-content/plugins/woocommerce-brands/includes/widgets/class-wc-widget-brand-nav.php
+function get_filtered_term_product_counts($request, $taxonomy)
+{
+    global $wpdb;
+
+    $term_ids = wp_list_pluck(get_terms(array(
+        'taxonomy'   => $taxonomy,
+        'hide_empty' => true,
+    )), 'term_id');
+
+    $tax_query  = array();
+    $meta_query = array();
+
+    $category = sanitize_text_field($request['category']);
+    if (isset($category) && $category) {
+        $tax_query[] = array(
+            'taxonomy' => 'product_cat',
+            'terms' => explode(',', $category),
+        );
+    }
+
+    $brand = sanitize_text_field($request['brand']);
+    if (isset($brand) && $brand) {
+        $tax_query[] = array(
+            'taxonomy' => 'product_brand',
+            'terms' => explode(',', $brand),
+        );
+    }
+
+    $tag = sanitize_text_field($request['tag']);
+    if (isset($tag) && $tag) {
+        $tax_query[] = array(
+            'taxonomy' => 'product_tag',
+            'terms' => explode(',', $tag),
+        );
+    }
+
+    $meta_query      = new WP_Meta_Query($meta_query);
+    $tax_query       = new WP_Tax_Query($tax_query);
+    $meta_query_sql  = $meta_query->get_sql('post', $wpdb->posts, 'ID');
+    $tax_query_sql   = $tax_query->get_sql($wpdb->posts, 'ID');
+
+    // Generate query
+    $query           = array();
+    $query['select'] = "SELECT COUNT( DISTINCT {$wpdb->posts}.ID ) as term_count, terms.term_id as term_count_id";
+    $query['from']   = "FROM {$wpdb->posts}";
+    $query['join']   = "
+			INNER JOIN {$wpdb->term_relationships} AS term_relationships ON {$wpdb->posts}.ID = term_relationships.object_id
+			INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy USING( term_taxonomy_id )
+			INNER JOIN {$wpdb->terms} AS terms USING( term_id )
+			" . $tax_query_sql['join'] . $meta_query_sql['join'];
+    $query['where']   = "
+			WHERE {$wpdb->posts}.post_type IN ( 'product' )
+			AND {$wpdb->posts}.post_status = 'publish'
+			" . $tax_query_sql['where'] . $meta_query_sql['where'] . "
+			AND terms.term_id IN (" . implode(',', array_map('absint', $term_ids)) . ")
+		";
+    $query['group_by'] = "GROUP BY terms.term_id";
+    $query             = apply_filters('woocommerce_get_filtered_term_product_counts_query', $query);
+    $query             = implode(' ', $query);
+
+    return $wpdb->get_results($query, ARRAY_A);
+}
+
 function getLangCodeFromConfigFile ($file) {
     return str_replace('config_', '', str_replace('.json', '',$file));
 }

--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -431,6 +431,7 @@ add_filter('woocommerce_rest_prepare_product_object', 'flutter_custom_change_pro
 add_filter('woocommerce_rest_prepare_product_review', 'custom_product_review', 20, 3);
 add_filter('woocommerce_rest_prepare_product_cat', 'custom_product_category', 20, 3);
 add_filter('woocommerce_rest_prepare_shop_order_object', 'flutter_custom_change_order_response', 20, 3);
+add_filter('woocommerce_rest_prepare_product_attribute', 'flutter_custom_change_product_attribute', 20, 3);
 
 function custom_product_category($response, $object, $request)
 {
@@ -471,6 +472,24 @@ function flutter_custom_change_product_response($response, $object, $request)
     return customProductResponse($response, $object, $request);
 }
 
+function flutter_custom_change_product_attribute($response, $item, $request)
+{
+    $taxonomy = wc_attribute_taxonomy_name($item->attribute_name);
+
+    $terms = get_filtered_term_product_counts($request, $taxonomy);
+
+    $is_visible = false;
+    foreach ($terms as $key => $term) {
+        if ($term['term_count'] > 0) {
+            $is_visible = true;
+            break;
+        }
+    }
+
+    $response->data['is_visible'] = $is_visible;
+
+    return $response;
+}
 
 function custom_get_attribute_taxonomy_name( $slug, $product ) {
 	// Format slug so it matches attributes of the product.


### PR DESCRIPTION
Ticket: https://support.inspireui.com/mailbox/tickets/26298

Add the `is_visible` parameter to the response when this attribute does not have any product

Example API: https://wclovers.mstore.io/wp-json/wc/v3/products/attributes?category=38&consumer_key=ck_cf6b2a2966f2d908cc08ebaef1336b15f9a6697c&consumer_secret=cs_9756800a6b17a6c76bcde454de61fd30ce389fad

Response
```json
[
    {
        "id": 1,
        "name": "color",
        "slug": "pa_color",
        "type": "select",
        "order_by": "menu_order",
        "has_archives": false,
        "is_visible": true,
        "_links": {
            "self": [
                {
                    "href": "https://wclovers.mstore.io/wp-json/wc/v3/products/attributes/1"
                }
            ],
            "collection": [
                {
                    "href": "https://wclovers.mstore.io/wp-json/wc/v3/products/attributes"
                }
            ]
        }
    },
    {
        "id": 2,
        "name": "size",
        "slug": "pa_size",
        "type": "select",
        "order_by": "menu_order",
        "has_archives": false,
        "is_visible": false,
        "_links": {
            "self": [
                {
                    "href": "https://wclovers.mstore.io/wp-json/wc/v3/products/attributes/2"
                }
            ],
            "collection": [
                {
                    "href": "https://wclovers.mstore.io/wp-json/wc/v3/products/attributes"
                }
            ]
        }
    }
]
```