### PR TITLE
feat(Tag): custom tag response api by cate, brand

### DIFF
--- a/mstore-api/functions/index.php
+++ b/mstore-api/functions/index.php
@@ -566,14 +566,20 @@ function customProductResponse($response, $object, $request)
 }
 
 /// Clone from wp-content/plugins/woocommerce-brands/includes/widgets/class-wc-widget-brand-nav.php
-function get_filtered_term_product_counts($request, $taxonomy)
+function get_filtered_term_product_counts($request, $taxonomy, $term_ids = [])
 {
     global $wpdb;
 
-    $term_ids = wp_list_pluck(get_terms(array(
-        'taxonomy'   => $taxonomy,
-        'hide_empty' => true,
-    )), 'term_id');
+    if (!isset($term_ids) || empty($term_ids)) {
+        $term_ids = wp_list_pluck(get_terms(array(
+            'taxonomy'   => $taxonomy,
+            'hide_empty' => true,
+        )), 'term_id');
+    }
+
+    if (!is_array($term_ids)) {
+        $term_ids = [$term_ids];
+    }
 
     $tax_query  = array();
     $meta_query = array();

--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -432,6 +432,7 @@ add_filter('woocommerce_rest_prepare_product_review', 'custom_product_review', 2
 add_filter('woocommerce_rest_prepare_product_cat', 'custom_product_category', 20, 3);
 add_filter('woocommerce_rest_prepare_shop_order_object', 'flutter_custom_change_order_response', 20, 3);
 add_filter('woocommerce_rest_prepare_product_attribute', 'flutter_custom_change_product_attribute', 20, 3);
+add_filter('woocommerce_rest_prepare_product_tag', 'flutter_custom_change_product_tag', 20, 3);
 
 function custom_product_category($response, $object, $request)
 {
@@ -477,6 +478,23 @@ function flutter_custom_change_product_attribute($response, $item, $request)
     $taxonomy = wc_attribute_taxonomy_name($item->attribute_name);
 
     $terms = get_filtered_term_product_counts($request, $taxonomy);
+
+    $is_visible = false;
+    foreach ($terms as $key => $term) {
+        if ($term['term_count'] > 0) {
+            $is_visible = true;
+            break;
+        }
+    }
+
+    $response->data['is_visible'] = $is_visible;
+
+    return $response;
+}
+
+function flutter_custom_change_product_tag($response, $item, $request)
+{
+    $terms = get_filtered_term_product_counts($request, $item->taxonomy, $item->term_id);
 
     $is_visible = false;
     foreach ($terms as $key => $term) {


### PR DESCRIPTION
Ticket: https://support.inspireui.com/mailbox/tickets/26298

Add the `is_visible` parameter to the response when this tag does not have any product

Example API: https://wclovers.mstore.io/wp-json/wc/v2/products/tags?per_page=9&page=1&hide_empty=true&lang=en&category=29,60&consumer_key=ck_cf6b2a2966f2d908cc08ebaef1336b15f9a6697c&consumer_secret=cs_9756800a6b17a6c76bcde454de61fd30ce389fad