### PR TITLE
feat(Product): get product by multi attribute

### DIFF
--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -434,6 +434,29 @@ add_filter('woocommerce_rest_prepare_product_cat', 'custom_product_category', 20
 add_filter('woocommerce_rest_prepare_shop_order_object', 'flutter_custom_change_order_response', 20, 3);
 add_filter('woocommerce_rest_prepare_product_attribute', 'flutter_custom_change_product_attribute', 20, 3);
 add_filter('woocommerce_rest_prepare_product_tag', 'flutter_custom_change_product_tag', 20, 3);
+add_filter('woocommerce_rest_product_object_query', 'flutter_custom_rest_product_object_query', 10, 2);
+
+function flutter_custom_rest_product_object_query($args, $request)
+{
+    $attrs = $request['attributes'];
+
+    if (is_string($attrs) && !empty($attrs)) {
+        $attrs = json_decode($attrs, true);
+    }
+
+    // Attributes filter.
+    if (!empty($attrs)) {
+        foreach ($attrs as $attr_key => $attr_value) {
+            $args['tax_query'][] = [
+                'taxonomy' => $attr_key,
+                'field'    => 'term_id',
+                'terms'    => explode(',', $attr_value),
+            ];
+        }
+    }
+
+    return $args;
+}
 
 function custom_product_category($response, $object, $request)
 {


### PR DESCRIPTION
Ticket: https://support.inspireui.com/mailbox/tickets/26298

Add the `attributes` parameter to the query to get products with multi attributes

Example API: https://wclovers.mstore.io/wp-json/wc/v3/products?status=publish&skip_cache=1&attributes=%7B%22pa_color%22:%2216,17%22,%22pa_size%22:%22234%22%7D&page=1&per_page=20&lang=en&currency=USD&is_all_data=true&consumer_key=ck_cf6b2a2966f2d908cc08ebaef1336b15f9a6697c&consumer_secret=cs_9756800a6b17a6c76bcde454de61fd30ce389fad