### PR TITLE
fix(PaidMembershipPro): fix call private function

### DIFF
--- a/mstore-api/controllers/flutter-paid-memberships-pro.php
+++ b/mstore-api/controllers/flutter-paid-memberships-pro.php
@@ -231,7 +231,14 @@ class FlutterPaidMembershipsPro extends FlutterBaseController
         $pmpro_level = pmpro_getLevelAtCheckout($planId);
         if($gateway == 'stripe' && !pmpro_isLevelFree( $pmpro_level )){
             $card = $params['card'];
-            $key = PMProGateway_stripe::get_secretkey();
+            $key = '';
+            if (PMProGateway_stripe::using_legacy_keys()) {
+                $key = get_option('pmpro_stripe_secretkey');
+            } else {
+                $key = get_option('pmpro_gateway_environment') === 'live'
+                ? get_option('pmpro_live_stripe_connect_secretkey')
+                : get_option('pmpro_sandbox_stripe_connect_secretkey');
+            }
             $s = new FlutterStripeHelper($key);
             $s->url .= 'payment_methods';
             $s->method = "POST";


### PR DESCRIPTION
In the new version of Paid Membership Pro, this `get_secretkey` function is made private so we cannot access it from outside that class

![image](https://github.com/inspireui/mstore-api/assets/52251635/fbd8439d-e22e-4ab2-adf7-03f110a09a93)

Solution: use this function instead
![image](https://github.com/inspireui/mstore-api/assets/52251635/6a1db458-4450-4b21-b7f8-4cb62307f07c)
