### PR TITLE
fix(AppWebview): cannot do some action if not set token

### DIFF
--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -838,13 +838,12 @@ function flutter_prepare_checkout()
             $user = get_userdata($userId);
             if ($user !== false) {
                 $cookie_elements = explode('|', $cookie);
-                if (count($cookie_elements) !== 4) {
-                    die;
+                if (count($cookie_elements) == 4) {
+                    list($username, $expiration, $token, $hmac) = $cookie_elements;
+                    $_COOKIE[LOGGED_IN_COOKIE] = $cookie;
+                    wp_set_current_user($userId, $user->user_login);
+                    wp_set_auth_cookie($userId, true, '', $token);
                 }
-                list($username, $expiration, $token, $hmac) = $cookie_elements;
-                $_COOKIE[LOGGED_IN_COOKIE] = $cookie;
-                wp_set_current_user($userId, $user->user_login);
-                wp_set_auth_cookie($userId, true, '', $token);
 
                 if (isset($_GET['order_detail']) && isset($_GET['order_id']) && is_plugin_active('dokan-lite/dokan.php')) {
                     $url = add_query_arg(

--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -837,7 +837,6 @@ function flutter_prepare_checkout()
         if (!is_wp_error($userId)) {
             $user = get_userdata($userId);
             if ($user !== false) {
-                wp_logout();
                 $cookie_elements = explode('|', $cookie);
                 if (count($cookie_elements) !== 4) {
                     die;

--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -837,29 +837,27 @@ function flutter_prepare_checkout()
         if (!is_wp_error($userId)) {
             $user = get_userdata($userId);
             if ($user !== false) {
+                wp_logout();
+                $cookie_elements = explode('|', $cookie);
+                if (count($cookie_elements) !== 4) {
+                    die;
+                }
+                list($username, $expiration, $token, $hmac) = $cookie_elements;
+                $_COOKIE[LOGGED_IN_COOKIE] = $cookie;
+                wp_set_current_user($userId, $user->user_login);
+                wp_set_auth_cookie($userId, true, '', $token);
+
                 if (isset($_GET['order_detail']) && isset($_GET['order_id']) && is_plugin_active('dokan-lite/dokan.php')) {
-					wp_logout();
-					$cookie_elements = explode( '|', $cookie );
-					if ( count( $cookie_elements ) !== 4 ) {
-						die;
-					}
-					list( $username, $expiration, $token, $hmac ) = $cookie_elements;
-					$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
-					wp_set_current_user($userId, $user->user_login);
-					wp_set_auth_cookie($userId, true, '', $token);
-					
                     $url = add_query_arg(
                         [
                             'order_id' => $_GET['order_id'],
-                            '_wpnonce' => wp_create_nonce( 'dokan_view_order' ),
-                        ], dokan_get_navigation_url( 'orders' )
+                            '_wpnonce' => wp_create_nonce('dokan_view_order'),
+                        ],
+                        dokan_get_navigation_url('orders')
                     );
-                    wp_safe_redirect( $url );
+                    wp_safe_redirect($url);
                     die;
-                }else{
-					wp_set_current_user($userId, $user->user_login);
-                	wp_set_auth_cookie($userId, true);
-				}
+                }
 
                 if (isset($_GET['vendor_admin'])) {
                     global $wp;


### PR DESCRIPTION
Ticket:
- https://support.inspireui.com/mailbox/tickets/27177
- https://support.inspireui.com/mailbox/tickets/25465 (need to check again after editing)

Reproduce:
If a user opens a web view using a cookie param, such as https://domain.com/wp-admin?cookie=123abc..., they may not be able to do some special actions, such as uploading images to media or deleting listings
After checking, I see the image upload action uses ajax POST but returns error code 403.
That's because when we check `$_GET['cookie']`, we set the auth cookie but not the token

Solution: Whenever a user uses the `GET` method to call a link with a cookie parameter, we set all auth cookie and token for that session again.

Note: Em chưa ngĩ ra có vấn đề gì với đoạn code bên ngoài if, có chăng là do mình call hàm `wp_logout();` không anh chứ logic là e thấy ko thay đổi.

Warning: This method may cause security issues ⚠️. Please change to a new approach to use webview without login on the app. You can close this PR if has another solution for this issue 😉