### PR TITLE
feat(SizeGuide): Support Product Size Guide API

### DIFF
--- a/mstore-api/controllers/flutter-woo.php
+++ b/mstore-api/controllers/flutter-woo.php
@@ -1435,6 +1435,10 @@ class FlutterWoo extends FlutterBaseController
 
             $result = ob_get_contents();
             ob_end_clean();
+        } else if (class_exists('PSCW_PRODUCT_SIZE_CHART_F_WOO_Front_end')) {
+            // Support Product Size Chart For WooCommerce Plugin:
+            // https://wordpress.org/plugins/product-size-chart-for-woo/
+            $result = $this->custom_product_tabs_content($product_id);
         }
 
         if(!isset($result) || empty($result)){
@@ -1444,6 +1448,49 @@ class FlutterWoo extends FlutterBaseController
                 'data' => $result
             );
         }
+    }
+
+    /// Clone from function `custom_product_tabs_content` of `PSCW_PRODUCT_SIZE_CHART_F_WOO_Front_end`
+    private function custom_product_tabs_content($post_id)
+    {
+        $html = '';
+
+        // Initialize controller manually
+        $controller = new PSCW_PRODUCT_SIZE_CHART_F_WOO_Front_end();
+        $controller->option        = get_option('woo_sc_setting');
+
+        $product_id           = $post_id;
+        $sizechart_id         = $controller->woo_sc_function->get_posts_id();
+        $sizechart_posts_data = [];
+        if (!empty($sizechart_id) && is_array($sizechart_id)) {
+            //rsort array size chart post id by DESC
+            rsort($sizechart_id);
+            foreach ($sizechart_id as $sizechart_post_id) {
+                $sizechart_posts_data[$sizechart_post_id] = get_post_meta($sizechart_post_id, 'woo_sc_size_chart_data', true);
+            }
+            foreach ($sizechart_posts_data as $sc_id => $val) {
+
+                $assign_product               = !empty($val['search_product']) ? $val['search_product'] : [];
+                $assign_cate                  = !empty($val['categories']) ? $val['categories'] : [];
+                $all_pro_id_in_assign_cate    = $controller->woo_sc_function->get_products_in_cate($assign_cate);
+                $all_product_ids_in_sizechart = array_merge($all_pro_id_in_assign_cate, $assign_product);
+                if (!empty($all_product_ids_in_sizechart) && is_array($all_product_ids_in_sizechart)) {
+                    $unique_product_id = array_unique($all_product_ids_in_sizechart);
+                }
+                if (!empty($unique_product_id) && is_array($unique_product_id)) {
+                    if (in_array($product_id, $unique_product_id)) {
+                        $get_meta_box_data = $controller->get_meta_box_data($sc_id);
+                        if (isset($get_meta_box_data['hide']) && $get_meta_box_data['hide'] !== 'hide_all') {
+                            $html .=  wp_kses_post($controller->woo_sc_function->content_data($sc_id));
+                        }
+                        if ($controller->option['multi_sc'] == "0") {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return $html;
     }
 }
 

--- a/mstore-api/controllers/flutter-woo.php
+++ b/mstore-api/controllers/flutter-woo.php
@@ -1441,7 +1441,7 @@ class FlutterWoo extends FlutterBaseController
             $result = $this->custom_product_tabs_content($product_id);
         }
 
-        if(!isset($result) || empty($result)){
+        if (!isset($result) || empty($result)) {
             return parent::sendError("invalid_data", "Not found", 400);
         } else {
             return array(
@@ -1458,6 +1458,7 @@ class FlutterWoo extends FlutterBaseController
         // Initialize controller manually
         $controller = new PSCW_PRODUCT_SIZE_CHART_F_WOO_Front_end();
         $controller->option        = get_option('woo_sc_setting');
+        $controller->option['position'] = 'product_tabs';
 
         $product_id           = $post_id;
         $sizechart_id         = $controller->woo_sc_function->get_posts_id();

--- a/mstore-api/controllers/flutter-woo.php
+++ b/mstore-api/controllers/flutter-woo.php
@@ -259,6 +259,22 @@ class FlutterWoo extends FlutterBaseController
                 }
             ),
         ));
+
+        register_rest_route($this->namespace, '/products/size-guide' . '/(?P<id>[\d]+)', array(
+            'args' => array(
+                'id' => array(
+                    'description' => __('Unique identifier for the resource.', 'woocommerce'),
+                    'type' => 'integer',
+                ),
+            ),
+            array(
+                'methods' => "GET",
+                'callback' => array($this, 'size_guide'),
+                'permission_callback' => function () {
+                    return parent::checkApiPermission();
+                }
+            ),
+        ));
     }
 
     private function get_post_id_from_meta($meta_key, $meta_value)
@@ -1401,6 +1417,32 @@ class FlutterWoo extends FlutterBaseController
             return $result[0];
         } else {
             return new WP_Error(400, "Unable to get product price", array('status' => 400));
+        }
+    }
+
+    function size_guide($request)
+    {
+        $params = $request->get_url_params();
+        $product_id = sanitize_text_field($params['id']);
+
+        if (function_exists('woodmart_sguide_display')) {
+            // Support WoodMart - Multipurpose WooCommerce Theme
+            ob_start();
+
+            // We can clone and customize this function if needed instead of
+            // using `ob_get_contents`
+            woodmart_sguide_display($product_id);
+
+            $result = ob_get_contents();
+            ob_end_clean();
+        }
+
+        if(!isset($result) || empty($result)){
+            return parent::sendError("invalid_data", "Not found", 400);
+        } else {
+            return array(
+                'data' => $result
+            );
         }
     }
 }


### PR DESCRIPTION
Tickets: https://support.inspireui.com/mailbox/tickets/27493 or https://inspireui.atlassian.net/browse/AF-355

Add API to get product size guide base on product id
- Support theme: [WoodMart - Multipurpose WooCommerce Theme](https://themeforest.net/item/woodmart-woocommerce-wordpress-theme/20264492)
- Plugin: [Product Size Chart For WooCommerce](https://wordpress.org/plugins/product-size-chart-for-woo/) (only product tab style https://take.ms/v56LY)

API: https://domain/wp-json/api/flutter_woo/products/size-guide/:id

Result:

Success
```json
{
    "data": "\t\t\t<style data-type=\"vc_shortcodes-custom-css\">\n\t\t\t\t\t\t\t\t\t\t\t/* */\n\t\t\t</style>\n\t\t\t<div id=\"woodmart_sizeguide\" class=\"mfp-with-anim mfp-hide wd-popup wd-sizeguide \">\n\t\t\t\t<h4 class=\"wd-sizeguide-title\">\n\t\t\t\t\tGuide size image\t\t\t\t</h4>\n\t\t\t\t<div class=\"wd-sizeguide-content\">\n\t\t\t\t\t<strong><p style=\"text-align: center;\"><a href=\"https://kokoletluxury.com/wp-content/uploads/2024/04/guide-size.png\"><img class=\"alignnone wp-image-13865 size-large\" src=\"https://kokoletluxury.com/wp-content/uploads/2024/04/guide-size-large.png\" alt=\"\" width=\"770\" height=\"443\" /></a></p></strong>\t\t\t\t</div>\n\t\t\t\t\t\t\t</div>\n\n\t\t\t<div class=\"wd-sizeguide-btn wd-action-btn wd-sizeguide-icon wd-style-text\">\n\t\t\t\t<a class=\"wd-open-popup\" rel=\"nofollow\" href=\"#woodmart_sizeguide\">\n\t\t\t\t\t<span>Size Guide</span>\n\t\t\t\t</a>\n\t\t\t</div>\n\t\t"
}
```

Fail
```json
{
    "code": "invalid_data",
    "message": "Not found",
    "data": {
        "status": 400
    }
}
```

Data as HTML String
```HTML
			<style data-type="vc_shortcodes-custom-css">
											/* */
			</style>
			<div id="woodmart_sizeguide" class="mfp-with-anim mfp-hide wd-popup wd-sizeguide ">
				<h4 class="wd-sizeguide-title">
					Guide size image				</h4>
				<div class="wd-sizeguide-content">
					<strong><p style="text-align: center;"><a href="https://kokoletluxury.com/wp-content/uploads/2024/04/guide-size.png"><img class="alignnone wp-image-13865 size-large" src="https://kokoletluxury.com/wp-content/uploads/2024/04/guide-size-large.png" alt="" width="770" height="443" /></a></p></strong>				</div>
							</div>

			<div class="wd-sizeguide-btn wd-action-btn wd-sizeguide-icon wd-style-text">
				<a class="wd-open-popup" rel="nofollow" href="#woodmart_sizeguide">
					<span>Size Guide</span>
				</a>
			</div>
		
```

Note: Should use image instead of HTML table to show guide chart because the app cannot load CSS from website and apply to show on the app 