### PR TITLE
feat(Scanner): support scan sku or id without any plugins

### DIFF
--- a/mstore-api/controllers/flutter-woo.php
+++ b/mstore-api/controllers/flutter-woo.php
@@ -313,6 +313,16 @@ class FlutterWoo extends FlutterBaseController
             $data = $this->get_post_id_from_meta($ean_key, $raw_data);
         }
 
+        // Get id from sku
+        if (!isset($data)) {
+            $data = $this->get_post_id_from_meta('_sku', $raw_data);
+        }
+
+        // Try to get id directly
+        if (!isset($data)) {
+            $data = $raw_data;
+        }
+
 		if(isset($data) && is_numeric($data)){
 			$type = get_post_type($data);
 			


### PR DESCRIPTION
Ticket: https://support.inspireui.com/mailbox/tickets/28616

### YITH WooCommerce Barcodes plugin (Already supported)
- [x] Product ID
- [x] Product SKU
- [x] Product custom field
- [x] Order ID

### EAN for WooCommerce plugin (Already supported)
- [x] Support default Meta key: `_alg_ean` (WooCommerce > Settings > EAN > Advanced > Advanced Options > Meta key)

### WooCommerce (Without any plugins)
- [x] Product ID
- [x] Product SKU
- [x] Order ID