### PR TITLE
🔧 Add filter to exclude Product IDs

### DIFF
--- a/mstore-api/controllers/flutter-vendor.php
+++ b/mstore-api/controllers/flutter-vendor.php
@@ -586,6 +586,14 @@ class FlutterVendor extends FlutterBaseController
                     );
                 }
             }
+            if (isset($request['exclude']) && !empty($request['exclude'])) {
+                $excluded_ids = array_map('intval', explode(',', $request['exclude']));
+                if (isset($args['post__not_in'])) {
+                    $args['post__not_in'] = array_merge($args['post__not_in'], $excluded_ids);
+                } else {
+                    $args['post__not_in'] = $excluded_ids;
+                }
+            }
             $products = get_posts($args);
         } else {
             global $woocommerce, $wpdb;


### PR DESCRIPTION
Add param `exclude` to hide productIDs in Vendor Store 

[URL to check result ](https://wclovers.mstore.io/wp-json/api/flutter_multi_vendor/products/owner?id=267&page=1&per_page=10&search=zephyr&lang=en&exclude=10410)