### PR TITLE
fix: woo warning and wordpress database error

### DIFF
--- a/mstore-api/controllers/flutter-user.php
+++ b/mstore-api/controllers/flutter-user.php
@@ -401,7 +401,10 @@ class FlutterUserController extends FlutterBaseController
         $userPassReq = $params["user_pass"];
         $userLoginReq = $params["user_login"];
         $userEmailReq = $params["user_email"];
-        $referralCodeReq = $params["referral_code"];
+
+        if (array_key_exists('referral_code', $params)) {
+            $referralCodeReq = $params["referral_code"];
+        }
 
         if(array_key_exists('role', $params)){
             $role = $params["role"];
@@ -473,7 +476,7 @@ class FlutterUserController extends FlutterBaseController
                 $_POST['user_role'] = $user['role'];//fix to register account with role in listeo
 
                 //
-                if ($referralCodeReq) {
+                if (isset($referralCodeReq) && $referralCodeReq) {
                     $_COOKIE['woo_wallet_referral'] = sanitize_text_field( wp_unslash( $referralCodeReq ) );
                 }
 

--- a/mstore-api/functions/index.php
+++ b/mstore-api/functions/index.php
@@ -663,6 +663,7 @@ function get_filtered_term_product_counts($request, $taxonomy, $term_ids = [], $
     $tax_query       = new WP_Tax_Query($tax_query);
     $meta_query_sql  = $meta_query->get_sql('post', $wpdb->posts, 'ID');
     $tax_query_sql   = $tax_query->get_sql($wpdb->posts, 'ID');
+    $term_ids_condition = !empty($term_ids) ? "AND terms.term_id IN (" . implode(',', array_map('absint', $term_ids)) . ")" : "";
 
     // Generate query
     $query           = array();
@@ -677,7 +678,7 @@ function get_filtered_term_product_counts($request, $taxonomy, $term_ids = [], $
 			WHERE {$wpdb->posts}.post_type IN ( 'product' )
 			AND {$wpdb->posts}.post_status = 'publish'
 			" . $tax_query_sql['where'] . $meta_query_sql['where'] . "
-			AND terms.term_id IN (" . implode(',', array_map('absint', $term_ids)) . ")
+			$term_ids_condition
 		";
     $query['group_by'] = "GROUP BY terms.term_id";
     $query             = apply_filters('woocommerce_get_filtered_term_product_counts_query', $query);

--- a/mstore-api/mstore-api.php
+++ b/mstore-api/mstore-api.php
@@ -355,11 +355,11 @@ class MstoreCheckOut
         trackNewOrder($order_id);
     }
 
-    //new order or update order via API
+    // New order or update order via API
     function track_api_new_order($object, $request, $creating)
     {
         if ($creating) {
-            trackNewOrder($object->id);
+            trackNewOrder($object->get_id());
 
             // Update order attributes. Requires WooCommerce 8.5.0 or later.
             // And make sure you have enabled `Order Attributes` in WooCommerce

--- a/mstore-api/templates/admin/mstore-api-admin-dashboard.php
+++ b/mstore-api/templates/admin/mstore-api-admin-dashboard.php
@@ -1,7 +1,7 @@
 
 <?php include_once(plugin_dir_path(dirname(dirname(__FILE__))) . 'functions/index.php'); ?>
 <?php include_once(plugin_dir_path(dirname(dirname(__FILE__))) . 'controllers/helpers/firebase-message-helper.php'); ?>
-
+<!-- 
     <div class="wrap">
         <div class="thanks">
             <p>Thank you for installing Mstore API plugins.</p>
@@ -15,13 +15,13 @@
             }
             ?>
         </div>
-    </div>
+    </div> -->
 <?php
 $verified = isPurchaseCodeVerified();
 if (!isset($verified) || $verified === "" || $verified === false) {
     ?>
     <form action="" enctype="multipart/form-data" method="post" style="margin-bottom:50px">
-        <?php
+        <!-- <?php
         if (isset($_POST['but_verify'])) {
             $verified = verifyPurchaseCode(sanitize_text_field($_POST['code']));
 
@@ -36,7 +36,7 @@ if (!isset($verified) || $verified === "" || $verified === false) {
                 <?php
             }
         }
-        ?>
+        ?> -->
 
         <input type="text" class="mstore-input-class" placeholder="Enter Purchase Code" name="code">
         <div>


### PR DESCRIPTION
Ticket: 28712

```
id was called incorrectly. Order properties should not be accessed directly. Backtrace: require('wp-blog-header.php'), wp, WP->main, WP->parse_request, do_action_ref_array('parse_request'), WP_Hook->do_action, WP_Hook->apply_filters, rest_api_loaded, WP_REST_Server->serve_request, WP_REST_Server->dispatch, WP_REST_Server->respond_to_request, CUSTOM_WC_REST_Orders_Controller->create_new_order, WC_REST_CRUD_Controller->create_item, do_action('woocommerce_rest_insert_shop_order_object'), WP_Hook->do_action, WP_Hook->apply_filters, MstoreCheckOut->track_api_new_order, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong. This message was added in version 3.0.
```
```
WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')
		 GROUP BY terms.term_id' at line 9 for query SELECT COUNT( DISTINCT wpw0_posts.ID ) as term_count, terms.term_id as term_count_id FROM wpw0_posts 
			INNER JOIN wpw0_term_relationships AS term_relationships ON wpw0_posts.ID = term_relationships.object_id
			INNER JOIN wpw0_term_taxonomy AS term_taxonomy USING( term_taxonomy_id )
			INNER JOIN wpw0_terms AS terms USING( term_id )
			 
			WHERE wpw0_posts.post_type IN ( 'product' )
			AND wpw0_posts.post_status = 'publish'
			
			AND terms.term_id IN ()
		 GROUP BY terms.term_id made by require('wp-blog-header.php'), wp, WP->main, WP->parse_request, do_action_ref_array('parse_request'), WP_Hook->do_action, WP_Hook->apply_filters, rest_api_loaded, WP_REST_Server->serve_request, WP_REST_Server->dispatch, WP_REST_Server->respond_to_request, WC_REST_Terms_Controller->get_items, apply_filters('woocommerce_rest_product_tag_query'), WP_Hook->apply_filters, flutter_custom_rest_product_tag_query, flutter_custom_rest_product_taxomomy_query, get_filtered_term_product_counts
[23-Jul-2024 22:37:22 UTC] WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')
		 GROUP BY terms.term_id' at line 9 for query SELECT COUNT( DISTINCT wpw0_posts.ID ) as term_count, terms.term_id as term_count_id FROM wpw0_posts 
			INNER JOIN wpw0_term_relationships AS term_relationships ON wpw0_posts.ID = term_relationships.object_id
			INNER JOIN wpw0_term_taxonomy AS term_taxonomy USING( term_taxonomy_id )
			INNER JOIN wpw0_terms AS terms USING( term_id )
			 
			WHERE wpw0_posts.post_type IN ( 'product' )
			AND wpw0_posts.post_status = 'publish'
			
			AND terms.term_id IN ()
		 GROUP BY terms.term_id made by require('wp-blog-header.php'), wp, WP->main, WP->parse_request, do_action_ref_array('parse_request'), WP_Hook->do_action, WP_Hook->apply_filters, rest_api_loaded, WP_REST_Server->serve_request, WP_REST_Server->dispatch, WP_REST_Server->respond_to_request, WC_REST_Terms_Controller->get_items, apply_filters('woocommerce_rest_product_tag_query'), WP_Hook->apply_filters, flutter_custom_rest_product_tag_query, flutter_custom_rest_product_taxomomy_query, get_filtered_term_product_counts
```
```
PHP Warning:  Undefined array key "referral_code" in /home/.../public_html/wp-content/plugins/mstore-api/controllers/flutter-user.php on line 404
```